### PR TITLE
Add stock movement

### DIFF
--- a/apps/ex_shop/lib/seed/load_products.ex
+++ b/apps/ex_shop/lib/seed/load_products.ex
@@ -12,7 +12,7 @@ defmodule Seed.LoadProducts do
   @product_data %{name: "Sample Product",
                   description: "Sample Product for testing without variant",
                   available_on: Ecto.Date.utc,
-                  master: %{cost_price: 20.00, quantity: 10}}
+                  master: %{cost_price: 20.00, add_quantity: 10}}
 
   defp seed_products_without_variant do
     # create the product
@@ -23,9 +23,9 @@ defmodule Seed.LoadProducts do
 
   @product_data %{name: "Sample Product 2",
                   description: "Sample Product for testing with 3 variants(One Master + 2 Other)",
-                  available_on: Ecto.Date.utc,master: %{cost_price: 10.00, quantity: 10}}
+                  available_on: Ecto.Date.utc,master: %{cost_price: 10.00, add_quantity: 10}}
   @variant_one_data %{discontinue_on: Ecto.Date.utc, cost_price: 20.00, sku: "Variant 1"}
-  @variant_two_data %{discontinue_on: Ecto.Date.utc, cost_price: 22.00, sku: "Variant 2", quantity: 11}
+  @variant_two_data %{discontinue_on: Ecto.Date.utc, cost_price: 22.00, sku: "Variant 2", add_quantity: 11}
   defp seed_products_with_variant do
     option_type = seed_option_type_and_values
     data = Map.merge(@product_data, %{product_option_types: [%{option_type_id: option_type.id}]})

--- a/apps/ex_shop/lib/seed/load_products.ex
+++ b/apps/ex_shop/lib/seed/load_products.ex
@@ -12,7 +12,7 @@ defmodule Seed.LoadProducts do
   @product_data %{name: "Sample Product",
                   description: "Sample Product for testing without variant",
                   available_on: Ecto.Date.utc,
-                  master: %{cost_price: 20.00, add_quantity: 10}}
+                  master: %{cost_price: 20.00, add_count: 10}}
 
   defp seed_products_without_variant do
     # create the product
@@ -23,9 +23,9 @@ defmodule Seed.LoadProducts do
 
   @product_data %{name: "Sample Product 2",
                   description: "Sample Product for testing with 3 variants(One Master + 2 Other)",
-                  available_on: Ecto.Date.utc,master: %{cost_price: 10.00, add_quantity: 10}}
+                  available_on: Ecto.Date.utc,master: %{cost_price: 10.00, add_count: 10}}
   @variant_one_data %{discontinue_on: Ecto.Date.utc, cost_price: 20.00, sku: "Variant 1"}
-  @variant_two_data %{discontinue_on: Ecto.Date.utc, cost_price: 22.00, sku: "Variant 2", add_quantity: 11}
+  @variant_two_data %{discontinue_on: Ecto.Date.utc, cost_price: 22.00, sku: "Variant 2", add_count: 11}
   defp seed_products_with_variant do
     option_type = seed_option_type_and_values
     data = Map.merge(@product_data, %{product_option_types: [%{option_type_id: option_type.id}]})

--- a/apps/ex_shop/priv/repo/migrations/20160301083751_add_fullfilled_to_line_item.exs
+++ b/apps/ex_shop/priv/repo/migrations/20160301083751_add_fullfilled_to_line_item.exs
@@ -1,0 +1,9 @@
+defmodule ExShop.Repo.Migrations.AddFullfilledToLineItem do
+  use Ecto.Migration
+
+  def change do
+    alter table(:line_items) do
+      add :fullfilled, :boolean, default: true
+    end
+  end
+end

--- a/apps/ex_shop/priv/repo/migrations/20160301083925_add_bought_quantity_to_variant.exs
+++ b/apps/ex_shop/priv/repo/migrations/20160301083925_add_bought_quantity_to_variant.exs
@@ -1,0 +1,10 @@
+defmodule ExShop.Repo.Migrations.AddBoughtQuantityToVariant do
+  use Ecto.Migration
+
+  def change do
+    alter table(:variants) do
+      add :bought_quantity, :integer
+    end
+    rename table(:variants), :quantity, to: :total_quantity
+  end
+end

--- a/apps/ex_shop/web/cart/checkout_manager.ex
+++ b/apps/ex_shop/web/cart/checkout_manager.ex
@@ -14,9 +14,7 @@ defmodule ExShop.CheckoutManager do
   def next_changeset(%Order{state: "shipping"} = order), do: Order.transition_changeset(order, "tax")
   def next_changeset(%Order{state: "tax"} = order), do: Order.transition_changeset(order, "payment")
   def next_changeset(%Order{state: "payment"} = order), do: Order.transition_changeset(order, "confirmation")
-  def next_changeset(%Order{} = order) do
-    order
-  end
+  def next_changeset(%Order{} = order), do: order
 
   # transitions
   # TODO: metaprogram to autogenerate
@@ -69,6 +67,11 @@ defmodule ExShop.CheckoutManager do
     order
     |> Order.settle_adjustments_and_product_payments
     |> Invoice.generate
+  end
+
+  def after_transition(%Order{state: "confirmation"} = order, _data) do
+    order
+    |> Order.acquire_variant_stock
   end
 
   # default match do nothing just return order

--- a/apps/ex_shop/web/controllers/admin/line_item_controller.ex
+++ b/apps/ex_shop/web/controllers/admin/line_item_controller.ex
@@ -30,4 +30,14 @@ defmodule ExShop.Admin.LineItemController do
     |> json(nil)
   end
 
+  def update_fullfillment(conn, %{"order_id" => id, "line_item_id" => line_item_id}) do
+    line_item = Repo.get!(LineItem, line_item_id) |> Repo.preload([:variant])
+    LineItem.fullfillment_changeset(line_item, %{fullfilled: !line_item.fullfilled})
+    |> Repo.update!
+    |> LineItem.move_stock
+    conn
+    |> put_status(:no_content)
+    |> json(nil)
+  end
+
 end

--- a/apps/ex_shop/web/models/line_item.ex
+++ b/apps/ex_shop/web/models/line_item.ex
@@ -50,29 +50,29 @@ defmodule ExShop.LineItem do
   end
 
   def move_stock(%ExShop.LineItem{fullfilled: true} = line_item) do
-    remove_stock_from_variant(line_item)
+    acquire_stock_from_variant(line_item)
   end
   def move_stock(%ExShop.LineItem{fullfilled: false} = line_item) do
-    move_stock_back_to_variant(line_item)
+    restock_variant(line_item)
   end
 
-  def remove_stock_from_variant(%ExShop.LineItem{variant: variant, quantity: quantity, fullfilled: true}) do
+  def acquire_stock_from_variant(%ExShop.LineItem{variant: variant, quantity: quantity, fullfilled: true}) do
     variant
     |> Variant.buy_changeset(%{buy_count: quantity})
     |> Repo.update!
   end
 
-  def remove_stock_from_variant(%ExShop.LineItem{variant: variant, quantity: quantity}) do
+  def acquire_stock_from_variant(%ExShop.LineItem{variant: variant, quantity: quantity}) do
     variant
   end
 
-  def move_stock_back_to_variant(%ExShop.LineItem{variant: variant, quantity: quantity, fullfilled: false}) do
+  def restock_variant(%ExShop.LineItem{variant: variant, quantity: quantity, fullfilled: false}) do
     variant
     |> Variant.restocking_changeset(%{restock_count: quantity})
     |> Repo.update!
   end
 
-  def move_stock_back_to_variant(%ExShop.LineItem{variant: variant, quantity: quantity}) do
+  def restock_variant(%ExShop.LineItem{variant: variant, quantity: quantity}) do
     variant
   end
 

--- a/apps/ex_shop/web/models/order.ex
+++ b/apps/ex_shop/web/models/order.ex
@@ -125,12 +125,12 @@ defmodule ExShop.Order do
   end
 
   def acquire_variant_stock(model) do
-    Enum.each(model.line_items, &ExShop.LineItem.remove_stock_from_variant/1)
+    Enum.each(model.line_items, &ExShop.LineItem.acquire_stock_from_variant/1)
     model
   end
 
   def restock_unfullfilled_line_items(model) do
-    Enum.each(model.line_items, &ExShop.LineItem.move_stock_back_to_variant/1)
+    Enum.each(model.line_items, &ExShop.LineItem.restock_variant/1)
     model
   end
 

--- a/apps/ex_shop/web/models/order.ex
+++ b/apps/ex_shop/web/models/order.ex
@@ -124,6 +124,16 @@ defmodule ExShop.Order do
     )
   end
 
+  def acquire_variant_stock(model) do
+    Enum.each(model.line_items, &ExShop.LineItem.remove_stock_from_variant/1)
+    model
+  end
+
+  def restock_unfullfilled_line_items(model) do
+    Enum.each(model.line_items, &ExShop.LineItem.move_stock_back_to_variant/1)
+    model
+  end
+
   def address_changeset(model, params \\ :empty) do
     model
     |> cast(params, @required_fields, @optional_fields)

--- a/apps/ex_shop/web/models/product.ex
+++ b/apps/ex_shop/web/models/product.ex
@@ -42,7 +42,7 @@ defmodule ExShop.Product do
   end
 
   def master_changeset(model, params \\ :empty) do
-    cast(model, params, ~w(cost_price), ~w(quantity))
+    cast(model, params, ~w(cost_price), ~w(add_count))
     |> put_change(:is_master, true)
     |> cast_attachments(params, ~w(), ~w(image))
   end

--- a/apps/ex_shop/web/models/variant.ex
+++ b/apps/ex_shop/web/models/variant.ex
@@ -56,13 +56,13 @@ defmodule ExShop.Variant do
   def buy_changeset(model, params \\ :empty) do
     model
     |> cast(params, ~w(buy_count), ~w())
-    |> update_bought_quantity
+    |> increment_bought_quantity
   end
 
   def restocking_changeset(model, params) do
     model
     |> cast(params, ~w(restock_count), ~w())
-    |> update_bought_quantity
+    |> decrement_bought_quantity
   end
 
   defp update_total_quantity(model) do
@@ -74,11 +74,19 @@ defmodule ExShop.Variant do
     end
   end
 
-  defp update_bought_quantity(model) do
-    quantity_to_add = model.changes[:buy_count] || 0
-    quantity_to_subtract = model.changes[:restock_count] || 0
-    if quantity_to_add || quantity_to_subtract do
-      put_change(model, :bought_quantity, (model.model.bought_quantity || 0) + quantity_to_add - quantity_to_subtract)
+  defp increment_bought_quantity(model) do
+    quantity_to_add = model.changes[:buy_count]
+    if quantity_to_add do
+      put_change(model, :bought_quantity, (model.model.bought_quantity || 0) + quantity_to_add)
+    else
+      model
+    end
+  end
+
+  defp decrement_bought_quantity(model) do
+    quantity_to_subtract = model.changes[:restock_count]
+    if quantity_to_subtract do
+      put_change(model, :bought_quantity, (model.model.bought_quantity || 0) - quantity_to_subtract)
     else
       model
     end

--- a/apps/ex_shop/web/models/variant.ex
+++ b/apps/ex_shop/web/models/variant.ex
@@ -13,7 +13,14 @@ defmodule ExShop.Variant do
     field :cost_price, :decimal
     field :cost_currency, :string
     field :image, ExShop.VariantImage.Type
-    field :quantity, :integer, default: 0
+
+    field :total_quantity, :integer, default: 0
+    field :add_count, :integer, virtual: true
+
+    field :bought_quantity, :integer, default: 0
+    field :buy_count, :integer, virtual: true
+
+    field :restock_count, :integer, virtual: true
 
     belongs_to :product, ExShop.Product
     has_many :variant_option_values, ExShop.VariantOptionValue, on_delete: :delete_all, on_replace: :delete
@@ -25,7 +32,7 @@ defmodule ExShop.Variant do
   end
 
   @required_fields ~w(is_master discontinue_on cost_price)
-  @optional_fields ~w(sku weight height width depth cost_currency quantity)
+  @optional_fields ~w(sku weight height width depth cost_currency add_count)
 
   @doc """
   Creates a changeset based on the `model` and `params`.
@@ -36,6 +43,7 @@ defmodule ExShop.Variant do
   def changeset(model, params \\ :empty) do
     model
     |> cast(params, @required_fields, @optional_fields)
+    |> update_total_quantity
   end
 
   def variant_changeset(model, params \\ :empty) do
@@ -44,4 +52,44 @@ defmodule ExShop.Variant do
     |> cast_attachments(params, ~w(), ~w(image))
     |> cast_assoc(:variant_option_values, required: true, with: &ExShop.VariantOptionValue.from_variant_changeset/2)
   end
+
+  def buy_changeset(model, params \\ :empty) do
+    model
+    |> cast(params, ~w(buy_count), ~w())
+    |> update_bought_quantity
+  end
+
+  def restocking_changeset(model, params) do
+    model
+    |> cast(params, ~w(restock_count), ~w())
+    |> update_bought_quantity
+  end
+
+  defp update_total_quantity(model) do
+    quantity_to_add = model.changes[:add_count]
+    if quantity_to_add do
+      put_change(model, :total_quantity, model.model.total_quantity + quantity_to_add)
+    else
+      model
+    end
+  end
+
+  defp update_bought_quantity(model) do
+    quantity_to_add = model.changes[:buy_count] || 0
+    quantity_to_subtract = model.changes[:restock_count] || 0
+    if quantity_to_add || quantity_to_subtract do
+      put_change(model, :bought_quantity, (model.model.bought_quantity || 0) + quantity_to_add - quantity_to_subtract)
+    else
+      model
+    end
+  end
+
+  def available_quantity(%ExShop.Variant{total_quantity: total_quantity, bought_quantity: bought_quantity}) when is_nil(bought_quantity) do
+    total_quantity
+  end
+
+  def available_quantity(%ExShop.Variant{total_quantity: total_quantity, bought_quantity: bought_quantity}) do
+    total_quantity - bought_quantity
+  end
+
 end

--- a/apps/ex_shop/web/router.ex
+++ b/apps/ex_shop/web/router.ex
@@ -38,7 +38,9 @@ defmodule ExShop.Router do
     get "/cart", OrderController, :cart
 
     resources "orders", OrderController, only: [:index, :show] do
-      resources "line_items", LineItemController, only: [:create, :delete]
+      resources "line_items", LineItemController, only: [:create, :delete] do
+        put "/update_fullfillment", LineItemController, :update_fullfillment
+      end
       get "/checkout", CheckoutController, :checkout
       put "/checkout/next", CheckoutController, :next
     end

--- a/apps/ex_shop/web/static/js/app.js
+++ b/apps/ex_shop/web/static/js/app.js
@@ -16,6 +16,7 @@ import ajax from "web/static/js/lib/ajax_setup";
 import zone from "web/static/js/zone";
 import state from "web/static/js/state";
 import order from "web/static/js/order";
+import order_show from "web/static/js/order_show";
 import payment from "web/static/js/payment";
 
 ajax.setup();
@@ -23,7 +24,7 @@ window.zone = zone;
 window.state = state;
 window.order = order;
 window.payment = payment;
-
+window.order_show = order_show;
 // Import local files
 //
 // Local files can be imported directly using relative

--- a/apps/ex_shop/web/static/js/order_show.js
+++ b/apps/ex_shop/web/static/js/order_show.js
@@ -19,6 +19,7 @@ export default {
   },
 
   updateFullfillment: function(lineItemId, fullfilled) {
+    let _this = this;
     $.ajax({
       url: `/admin/orders/${this.orderId}/line_items/${lineItemId}/update_fullfillment`,
       data: {
@@ -27,8 +28,14 @@ export default {
         }
       },
       contentType: "application/json",
-      method: 'put'
+      method: 'put',
+      success: function() {
+        _this.removeCheckbox(lineItemId);
+      }
     });
+  },
+  removeCheckbox: function(lineItemId) {
+    this.lineItems.find(`.fullfillment[data-line-item-id=${lineItemId}]`).replaceWith("<strong>cancelled</strong>");
   }
 
 }

--- a/apps/ex_shop/web/static/js/order_show.js
+++ b/apps/ex_shop/web/static/js/order_show.js
@@ -1,0 +1,34 @@
+export default {
+  lineItems: $("#line_items"),
+  init: function(id) {
+    this.orderId = id;
+    this.bindEvents();
+  },
+  bindEvents: function() {
+    this.bindFullfillmentToggle();
+  },
+
+  bindFullfillmentToggle: function() {
+    let _this = this;
+    this.lineItems.on('change', '.fullfillment', function() {
+      let checkbox = $(this);
+      let fullfilled = checkbox.checked;
+      let lineItemId = checkbox.data('line-item-id');
+      _this.updateFullfillment(lineItemId, fullfilled);
+    });
+  },
+
+  updateFullfillment: function(lineItemId, fullfilled) {
+    $.ajax({
+      url: `/admin/orders/${this.orderId}/line_items/${lineItemId}/update_fullfillment`,
+      data: {
+        line_item: {
+          fullfilled: fullfilled
+        }
+      },
+      contentType: "application/json",
+      method: 'put'
+    });
+  }
+
+}

--- a/apps/ex_shop/web/templates/admin/order/script.show.html.eex
+++ b/apps/ex_shop/web/templates/admin/order/script.show.html.eex
@@ -1,0 +1,1 @@
+<script>order_show.init(<%= @order.id %>)</script>

--- a/apps/ex_shop/web/templates/admin/order/show.html.eex
+++ b/apps/ex_shop/web/templates/admin/order/show.html.eex
@@ -13,15 +13,23 @@
       <td>Quantity</td>
       <td>Cost Per Product</td>
       <td>Total</td>
+      <td>Fullfilled</td>
     </tr>
   </thead>
-  <tbody>
+  <tbody id="line_items">
     <%= for line_item <- @order.line_items do %>
       <tr>
         <td><%= line_item.variant.product.name %></td>
         <td><%= line_item.quantity %></td>
         <td><%= line_item.variant.cost_price %></td>
         <td><%= line_item.total %></td>
+        <td>
+          <%= if line_item.fullfilled do %>
+            <input name="" type="checkbox" checked="<%= line_item.fullfilled %>" class="fullfillment" data-line-item-id="<%= line_item.id %>"/>
+          <% else %>
+            <input name="" type="checkbox" class="fullfillment" data-line-item-id="<%= line_item.id %>"/>
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/apps/ex_shop/web/templates/admin/order/show.html.eex
+++ b/apps/ex_shop/web/templates/admin/order/show.html.eex
@@ -27,7 +27,7 @@
           <%= if line_item.fullfilled do %>
             <input name="" type="checkbox" checked="<%= line_item.fullfilled %>" class="fullfillment" data-line-item-id="<%= line_item.id %>"/>
           <% else %>
-            <input name="" type="checkbox" class="fullfillment" data-line-item-id="<%= line_item.id %>"/>
+            <strong>cancelled</strong>
           <% end %>
         </td>
       </tr>

--- a/apps/ex_shop/web/templates/admin/product/form.html.eex
+++ b/apps/ex_shop/web/templates/admin/product/form.html.eex
@@ -37,9 +37,9 @@
     </div>
 
     <div class="form-group">
-      <%= label m, :quantity, class: "control-label" %>
-      <%= text_input m, :quantity, class: "form-control" %>
-      <%= error_tag m, :quantity %>
+      <%= label m, :add_count,"Add Stock", class: "control-label" %>
+      <%= number_input m, :add_count, class: "form-control" %>
+      <%= error_tag m, :add_count %>
     </div>
 
     <%= if @changeset.model.id do %>

--- a/apps/ex_shop/web/templates/admin/variant/form.html.eex
+++ b/apps/ex_shop/web/templates/admin/variant/form.html.eex
@@ -58,8 +58,8 @@
   </div>
 
   <div class="form-group">
-    <%= label f, :quantity, class: "control-label" %>
-    <%= number_input f, :quantity, class: "form-control" %>
+    <%= label f, :add_count, "Add stock", class: "control-label" %>
+    <%= number_input f, :add_count, class: "form-control" %>
     <%= error_tag f, :quantity %>
   </div>
 

--- a/apps/ex_shop/web/templates/admin/variant/show.html.eex
+++ b/apps/ex_shop/web/templates/admin/variant/show.html.eex
@@ -17,7 +17,9 @@
   <div class="panel panel-default">
     <div class="panel-body pull-left">$ <%= @variant.cost_price %></div>
     <div class="panel-body pull-left"><%= @variant.product.available_on %></div>
-    <div class="panel-body"<%= @variant.discontinue_on %>></div>
+    <div class="panel-body"><%= @variant.discontinue_on %></div>
+    <div class="panel-body">Total:  <%= @variant.total_quantity %></div>
+    <div class="panel-body">Bought: <%= @variant.bought_quantity %></div>
   </div>
   <%= for option_value <- @variant.option_values do %>
     <div class="panel panel-default">

--- a/apps/ex_shop/web/views/admin/order_view.ex
+++ b/apps/ex_shop/web/views/admin/order_view.ex
@@ -4,8 +4,7 @@ defmodule ExShop.Admin.OrderView do
   def only_master_variant?(%ExShop.Product{variants: [_]}), do: true
   def only_master_variant?(%ExShop.Product{variants: [_|_]}), do: false
 
-  def out_of_stock?(%ExShop.Variant{quantity: 0}), do: true
-  def out_of_stock?(%ExShop.Variant{quantity: quantity}) when quantity > 0, do: false
+  def out_of_stock?(%ExShop.Variant{} = variant), do: ExShop.Variant.available_quantity(variant) == 0
 
   def product_variant_options(%ExShop.Product{} = product) do
     Enum.map(product.variants, fn (variant) ->


### PR DESCRIPTION
1. Adds bought count and total count to variant.
2. Allow admin to piecemeal cancel line items
3. Update views to add to stock instead of directly changing the value.
