### PR TITLE
[Date Validations] Product Available_on and Master variant Discontinue_on

### DIFF
--- a/apps/ex_shop/test/cart/checkout_manager_test.exs
+++ b/apps/ex_shop/test/cart/checkout_manager_test.exs
@@ -306,7 +306,7 @@ defmodule ExShop.CheckoutManagerTest do
     %{"shipping" => %{"shipping_method_id" => shipping_method_id}}
   end
 
-  defp valid_payment_params(cart) do
+  defp valid_payment_params(_cart) do
     payment_method_id = create_payment_methods |> List.first |> Map.get(:id)
     %{"payment" => %{"payment_method_id" => payment_method_id}, "payment_method" => %{}}
   end

--- a/apps/ex_shop/test/controllers/admin/checkout_controller_test.exs
+++ b/apps/ex_shop/test/controllers/admin/checkout_controller_test.exs
@@ -115,12 +115,12 @@ defmodule ExShop.Admin.CheckoutControllerTest do
     end)
   end
 
-  defp valid_shipping_params(%Order{"id": id}) do
+  defp valid_shipping_params(%Order{"id": _id}) do
     shipping_method_id = create_shipping_methods |> List.first |> Map.get(:id)
     %{"shipping" => %{"shipping_method_id" => shipping_method_id}}
   end
 
-  defp valid_payment_params(%Order{"id": id}) do
+  defp valid_payment_params(%Order{"id": _id}) do
     payment_method_id = create_payment_methods |> List.first |> Map.get(:id)
     %{"payment" => %{"payment_method_id" => payment_method_id}}
   end

--- a/apps/ex_shop/test/controllers/admin/product_controller_test.exs
+++ b/apps/ex_shop/test/controllers/admin/product_controller_test.exs
@@ -8,7 +8,7 @@ defmodule ExShop.Admin.ProductControllerTest do
   @product_attrs %{
     name: "Reebok Premium",
     description: "Reebok Premium Exclusively for you",
-    available_on: "2010-04-17 14:00:00"
+    available_on: Ecto.Date.utc
   }
   @master_variant_attrs %{
     master: %{

--- a/apps/ex_shop/test/controllers/admin/variant_controller_test.exs
+++ b/apps/ex_shop/test/controllers/admin/variant_controller_test.exs
@@ -10,7 +10,7 @@ defmodule ExShop.Admin.VariantControllerTest do
   @product_attrs %{
     name: "Reebok Premium",
     description: "Reebok Premium Exclusively for you",
-    available_on: "2010-04-17 14:00:00"
+    available_on: Ecto.Date.utc
   }
   @master_variant_attrs %{
     master: %{
@@ -43,7 +43,7 @@ defmodule ExShop.Admin.VariantControllerTest do
   }
   @valid_attrs %{
     cost_price: "120.5",
-    discontinue_on: %{"year" => "2016", "month" => "2", "day" => "1"},
+    discontinue_on: Ecto.Date.utc,
     height: "120.5", weight: "120.5", width: "120.5",
     sku: "URG123"
   }
@@ -180,7 +180,7 @@ defmodule ExShop.Admin.VariantControllerTest do
   defp get_valid_variant_params(data) do
     option_type = data.option_type
     option_values = option_type.option_values
-    first_option_value = Enum.at(option_values, 1)
+    first_option_value = Enum.at(option_values, 0)
     valid_variant_option_value_attrs = %{
       variant_option_values: [
         %{

--- a/apps/ex_shop/test/models/line_item_test.exs
+++ b/apps/ex_shop/test/models/line_item_test.exs
@@ -37,7 +37,7 @@ defmodule ExShop.LineItemTest do
 
   @valid_variant_attrs %{
     cost_price: "120.5",
-    discontinue_on: %{"year" => "2016", "month" => "2", "day" => "1"},
+    discontinue_on: Ecto.Date.utc,
     height: "120.5", weight: "120.5", width: "120.5",
     sku: "URG123"
   }
@@ -123,7 +123,7 @@ defmodule ExShop.LineItemTest do
     assert c_confirm.state == "confirmation"
     assert c_confirm.confirmation_status
 
-    {status, line_item} = ExShop.LineItem.cancel_fullfillment(%ExShop.LineItem{line_item|order: c_confirm})
+    {_status, line_item} = ExShop.LineItem.cancel_fullfillment(%ExShop.LineItem{line_item|order: c_confirm})
     refute line_item.fullfilled
 
     updated_order = ExShop.Repo.get(ExShop.Order, order_id)
@@ -154,7 +154,7 @@ defmodule ExShop.LineItemTest do
 
   defp create_product_with_variant do
     product = create_product
-    master_variant = product.master
+    #master_variant = product.master
     product
     |> build_assoc(:variants)
     |> Variant.create_variant_changeset(@valid_variant_attrs)
@@ -246,7 +246,7 @@ defmodule ExShop.LineItemTest do
     %{"shipping" => %{"shipping_method_id" => shipping_method_id}}
   end
 
-  defp valid_payment_params(cart) do
+  defp valid_payment_params(_cart) do
     payment_method_id = create_payment_methods |> List.first |> Map.get(:id)
     %{"payment" => %{"payment_method_id" => payment_method_id}, "payment_method" => %{}}
   end

--- a/apps/ex_shop/test/models/product_test.exs
+++ b/apps/ex_shop/test/models/product_test.exs
@@ -4,7 +4,8 @@ defmodule ExShop.ProductTest do
   alias ExShop.Repo
   alias ExShop.Product
 
-  import ExShop.DateTestHelpers
+  import ExShop.DateTestHelpers, only: [get_past_date: 0, get_current_date: 0, get_future_date: 1]
+  import ExShop.TestSetup.Product, only: [create_product: 0]
 
 
   @valid_attrs %{available_on: "2010-04-17 14:00:00", description: "some content", discontinue_on: "2010-04-17 14:00:00", name: "some content"}
@@ -25,7 +26,7 @@ defmodule ExShop.ProductTest do
     master_variant = Repo.one(Product.master_variant(product))
 
     changeset = Product.update_changeset(product, %{"master" => %{"discontinue_on" => get_past_date, "id" => master_variant.id}})
-    assert changeset.changes.master.errors == [discontinue_on: "should be greater than #{Ecto.Date.utc}", discontinue_on: "can not be past date"]
+    assert changeset.changes.master.errors == [discontinue_on: "should be greater or same as #{Ecto.Date.utc}", discontinue_on: "can not be past date"]
   end
 
   test "Available on should be less than Master Variant discontinue_on" do
@@ -42,7 +43,7 @@ defmodule ExShop.ProductTest do
     assert master_variant.discontinue_on == get_future_date(5)
 
     changeset = Product.update_changeset(product, %{"available_on" => get_future_date(7)})
-    assert changeset.errors == [available_on: "should be less than #{get_future_date(5)}"]
+    assert changeset.errors == [available_on: "should be less or same as #{get_future_date(5)}"]
 
     changeset = Product.update_changeset(product, %{
       "available_on" => get_future_date(7),
@@ -50,24 +51,6 @@ defmodule ExShop.ProductTest do
         "discontinue_on" => get_future_date(6), "id" => master_variant.id
       }
     })
-    assert changeset.errors == [available_on: "should be less than #{get_future_date(6)}"]
-  end
-
-  @product_attrs %{
-    name: "Reebok Premium",
-    description: "Reebok Premium Exclusively for you",
-    available_on: Ecto.Date.utc
-  }
-  @master_variant_attrs %{
-    master: %{
-      cost_price: "20"
-    }
-  }
-  @valid_product_attrs Map.merge(@product_attrs, @master_variant_attrs)
-
-  defp create_product do
-    product_changeset = Product.create_changeset(%Product{}, @valid_product_attrs)
-    product = Repo.insert! product_changeset
-    product |> Repo.preload(:product_option_types)
+    assert changeset.errors == [available_on: "should be less or same as #{get_future_date(6)}"]
   end
 end

--- a/apps/ex_shop/test/models/product_test.exs
+++ b/apps/ex_shop/test/models/product_test.exs
@@ -1,7 +1,11 @@
 defmodule ExShop.ProductTest do
   use ExShop.ModelCase
 
+  alias ExShop.Repo
   alias ExShop.Product
+
+  import ExShop.DateTestHelpers
+
 
   @valid_attrs %{available_on: "2010-04-17 14:00:00", description: "some content", discontinue_on: "2010-04-17 14:00:00", name: "some content"}
   @invalid_attrs %{}
@@ -14,5 +18,56 @@ defmodule ExShop.ProductTest do
   test "changeset with invalid attributes" do
     changeset = Product.changeset(%Product{}, @invalid_attrs)
     refute changeset.valid?
+  end
+
+  test "Discontinue on should not be past date and greater than product available_on" do
+    product = create_product
+    master_variant = Repo.one(Product.master_variant(product))
+
+    changeset = Product.update_changeset(product, %{"master" => %{"discontinue_on" => get_past_date, "id" => master_variant.id}})
+    assert changeset.changes.master.errors == [discontinue_on: "should be greater than #{Ecto.Date.utc}", discontinue_on: "can not be past date"]
+  end
+
+  test "Available on should be less than Master Variant discontinue_on" do
+    product = create_product
+    master_variant = Repo.one(Product.master_variant(product))
+
+    product = Product.update_changeset(product, %{"master" => %{"discontinue_on" => get_future_date(5), "id" => master_variant.id}})
+      |> Repo.update!
+
+    master_variant = product
+      |> Product.master_variant
+      |> Repo.one
+
+    assert master_variant.discontinue_on == get_future_date(5)
+
+    changeset = Product.update_changeset(product, %{"available_on" => get_future_date(7)})
+    assert changeset.errors == [available_on: "should be less than #{get_future_date(5)}"]
+
+    changeset = Product.update_changeset(product, %{
+      "available_on" => get_future_date(7),
+      "master" => %{
+        "discontinue_on" => get_future_date(6), "id" => master_variant.id
+      }
+    })
+    assert changeset.errors == [available_on: "should be less than #{get_future_date(6)}"]
+  end
+
+  @product_attrs %{
+    name: "Reebok Premium",
+    description: "Reebok Premium Exclusively for you",
+    available_on: Ecto.Date.utc
+  }
+  @master_variant_attrs %{
+    master: %{
+      cost_price: "20"
+    }
+  }
+  @valid_product_attrs Map.merge(@product_attrs, @master_variant_attrs)
+
+  defp create_product do
+    product_changeset = Product.create_changeset(%Product{}, @valid_product_attrs)
+    product = Repo.insert! product_changeset
+    product |> Repo.preload(:product_option_types)
   end
 end

--- a/apps/ex_shop/test/models/variant_test.exs
+++ b/apps/ex_shop/test/models/variant_test.exs
@@ -1,18 +1,118 @@
 defmodule ExShop.VariantTest do
   use ExShop.ModelCase
 
+  alias ExShop.Product
   alias ExShop.Variant
 
-  @valid_attrs %{cost_currency: "some content", cost_price: "120.5", depth: 42, discontinue_on: "2010-04-17 14:00:00", height: 42, is_master: true, sku: "some content", weight: 42, width: 42}
+  import ExShop.DateTestHelpers, only: [get_past_date: 0, get_current_date: 0, get_future_date: 1]
+  import ExShop.TestSetup.Variant, only: [create_variant: 0, create_product_with: 1]
+
+  import ExShop.TestSetup.OptionType, only: [create_option_type: 0]
+  import ExShop.TestSetup.Product, only: [create_product: 0]
+
+  @variant_attrs %{
+    cost_currency: "INR", cost_price: "30", weight: 3, height: 3, width: 3, depth: 3,
+    discontinue_on: Ecto.Date.utc, sku: "SKU 123"
+  }
   @invalid_attrs %{}
 
   test "changeset with valid attributes" do
-    changeset = Variant.changeset(%Variant{}, @valid_attrs)
+    option_type = create_option_type
+    assert option_type.id
+
+    product = create_product
+    assert product.id
+
+    product = Product.update_changeset(product, %{
+        product_option_types: [
+          %{option_type_id: option_type.id}
+        ]
+      })
+      |> Repo.update!
+
+    assert product.product_option_types
+
+    last_option_value = Enum.at(option_type.option_values, 1)
+    assert last_option_value
+
+    changeset = product
+      |> build_assoc(:variants)
+      |> Variant.create_variant_changeset(
+        Map.merge(@variant_attrs, %{
+          variant_option_values: [
+            %{
+              option_type_id: option_type.id,
+              option_value_id: last_option_value.id
+            }
+          ]
+        })
+      )
+
     assert changeset.valid?
   end
 
   test "changeset with invalid attributes" do
-    changeset = Variant.changeset(%Variant{}, @invalid_attrs)
+    option_type = create_option_type
+    assert option_type.id
+
+    product = create_product_with(option_type)
+    assert product.id
+    assert product.product_option_types
+
+    last_option_value = Enum.at(option_type.option_values, 1)
+    assert last_option_value
+
+    changeset = product
+      |> build_assoc(:variants)
+      |> Variant.create_variant_changeset(
+        Map.merge(@invalid_attrs, %{
+          variant_option_values: [
+            %{
+              option_type_id: option_type.id,
+              option_value_id: last_option_value.id
+            }
+          ]
+        })
+      )
+
     refute changeset.valid?
+  end
+
+  test "Create: Discontinue on should not be past date and greater than product available_on" do
+    option_type = create_option_type
+    assert option_type.id
+
+    product = create_product_with(option_type)
+    assert product.id
+    assert product.product_option_types
+
+    last_option_value = Enum.at(option_type.option_values, 1)
+    assert last_option_value
+
+    changeset = product
+      |> build_assoc(:variants)
+      |> Variant.create_variant_changeset(
+        Map.merge(@variant_attrs, %{
+          variant_option_values: [
+            %{
+              option_type_id: option_type.id,
+              option_value_id: last_option_value.id
+            }
+          ],
+          discontinue_on: get_past_date
+        })
+      )
+
+    assert changeset.errors == [discontinue_on: "should be greater or same as #{Ecto.Date.utc}", discontinue_on: "can not be past date"]
+  end
+
+  test "Update: Discontinue on should not be past date and greater than product available_on" do
+    %{product: product, variant: variant, option_type: _option_type} = create_variant
+
+    assert product.id
+    assert variant.id
+
+    changeset = Variant.update_variant_changeset(variant, %{"discontinue_on" => get_past_date})
+    assert changeset.errors == [discontinue_on: "should be greater or same as #{Ecto.Date.utc}", discontinue_on: "can not be past date"]
   end
 end

--- a/apps/ex_shop/test/support/date_test_helpers.ex
+++ b/apps/ex_shop/test/support/date_test_helpers.ex
@@ -1,0 +1,21 @@
+defmodule ExShop.DateTestHelpers do
+  def get_past_date(days \\ 1) do
+    {:ok, {y,m,d}} = Ecto.Date.dump(get_current_date)
+    # Not safe as would fail on edge dates :(
+    prev_day = d - days
+    {:ok, prev_date} = Ecto.Date.load({y,m,prev_day})
+    prev_date
+  end
+
+  def get_current_date do
+    Ecto.Date.utc
+  end
+
+  def get_future_date(days \\ 1) do
+    {:ok, {y,m,d}} = Ecto.Date.dump(get_current_date)
+    # Not safe as would fail on edge dates :(
+    next_day = d + days
+    {:ok, next_date} = Ecto.Date.load({y,m,next_day})
+    next_date
+  end
+end

--- a/apps/ex_shop/test/support/test_setup/option_type.ex
+++ b/apps/ex_shop/test/support/test_setup/option_type.ex
@@ -1,0 +1,25 @@
+defmodule ExShop.TestSetup.OptionType do
+  alias ExShop.Repo
+  alias ExShop.OptionType
+
+  @option_type_attrs %{
+    name: "Color", # Can lead to intermittent issues failing unique validation
+    presentation: "Color",
+    option_values: [
+      %{
+        name: "Red",
+        presentation: "Red"
+      },
+      %{
+        name: "Green",
+        presentation: "Green"
+      }
+    ]
+  }
+
+  def create_option_type do
+    option_type_changeset = OptionType.changeset(%OptionType{}, @option_type_attrs)
+    option_type = Repo.insert!(option_type_changeset)
+      |> Repo.preload([:option_values])
+  end
+end

--- a/apps/ex_shop/test/support/test_setup/product.ex
+++ b/apps/ex_shop/test/support/test_setup/product.ex
@@ -1,0 +1,22 @@
+defmodule ExShop.TestSetup.Product do
+  alias ExShop.Repo
+  alias ExShop.Product
+
+  @product_attrs %{
+    name: "Reebok Premium",
+    description: "Reebok Premium Exclusively for you",
+    available_on: Ecto.Date.utc
+  }
+  @master_variant_attrs %{
+    master: %{
+      cost_price: "20"
+    }
+  }
+  @valid_product_attrs Map.merge(@product_attrs, @master_variant_attrs)
+
+  def create_product do
+    product_changeset = Product.create_changeset(%Product{}, @valid_product_attrs)
+    product = Repo.insert! product_changeset
+    product |> Repo.preload(:product_option_types)
+  end
+end

--- a/apps/ex_shop/test/support/test_setup/variant.ex
+++ b/apps/ex_shop/test/support/test_setup/variant.ex
@@ -1,0 +1,137 @@
+defmodule ExShop.TestSetup.Variant do
+  import Ecto
+
+  alias ExShop.Repo
+  alias ExShop.OptionType
+  alias ExShop.Product
+  alias ExShop.Variant
+
+  @product_attrs %{
+    name: "Reebok Premium",
+    description: "Reebok Premium Exclusively for you",
+    available_on: Ecto.Date.utc
+  }
+  @master_variant_attrs %{
+    master: %{
+      cost_price: "20"
+    }
+  }
+
+  @valid_product_attrs Map.merge(@product_attrs, @master_variant_attrs)
+
+  @option_type_attrs %{
+    name: "Color", # Can lead to intermittent issues failing unique validation
+    presentation: "Color",
+    option_values: [
+      %{
+        name: "Red",
+        presentation: "Red"
+      },
+      %{
+        name: "Green",
+        presentation: "Green"
+      }
+    ]
+  }
+
+  @variant_option_value_attrs %{
+    variant_option_values: [
+      %{
+        option_value_id: "1",
+        option_type_id: "1"
+      }
+    ]
+  }
+
+  @variant_attrs %{
+    cost_price: "30",
+    discontinue_on: Ecto.Date.utc,
+    height: "2", weight: "2", width: "2",
+    sku: "URG123"
+  }
+
+  defp create_option_type do
+    option_type_changeset = OptionType.changeset(%OptionType{}, @option_type_attrs)
+    option_type = Repo.insert!(option_type_changeset)
+      |> Repo.preload([:option_values])
+  end
+
+  def create_product_with(option_type) do
+    product_option_type_attrs = %{
+      product_option_types: [
+        %{
+          option_type_id: option_type.id
+        }
+      ]
+    }
+    valid_product_with_option_type_attrs = Map.merge(@valid_product_attrs, product_option_type_attrs)
+    product = Product.create_changeset(%Product{}, valid_product_with_option_type_attrs)
+      |> Repo.insert!
+  end
+
+  defp get_valid_variant_params(option_type) do
+    option_values = option_type.option_values
+    first_option_value = Enum.at(option_values, 0)
+    valid_variant_option_value_attrs = %{
+      variant_option_values: [
+        %{
+          option_type_id: option_type.id,
+          option_value_id: first_option_value.id
+        }
+      ]
+    }
+    valid_variant_with_option_value_attrs = Map.merge(@variant_attrs, valid_variant_option_value_attrs)
+    valid_variant_with_option_value_attrs
+  end
+
+  def create_variant do
+    option_type = create_option_type
+    product = create_product_with(option_type)
+
+    valid_variant_with_option_value_attrs = get_valid_variant_params(option_type)
+
+    variant = product
+      |> build_assoc(:variants)
+      |> Variant.create_variant_changeset(valid_variant_with_option_value_attrs)
+      |> Repo.insert!
+
+    %{product: product, variant: variant, option_type: option_type}
+  end
+
+  defp example_setup do
+    option_type = create_option_type
+    assert option_type.id
+
+    ## Need to import Product test-setup module
+    ## Changed here as create_product_with
+    product = create_product
+    assert product.id
+
+    product = Product.update_changeset(product, %{
+        product_option_types: [
+          %{option_type_id: option_type.id}
+        ]
+      })
+      |> Repo.update!
+
+    assert product.product_option_types
+
+    last_option_value = Enum.at(option_type.option_values, 1)
+    assert last_option_value
+
+    changeset = product
+      |> build_assoc(:variants)
+      |> Variant.create_variant_changeset(
+        Map.merge(@variant_attrs, %{
+          variant_option_values: [
+            %{
+              option_type_id: option_type.id,
+              option_value_id: last_option_value.id
+            }
+          ]
+        })
+      )
+
+    assert changeset.valid?
+  end
+end

--- a/apps/ex_shop/test/validations/date_test.exs
+++ b/apps/ex_shop/test/validations/date_test.exs
@@ -1,0 +1,48 @@
+defmodule Validations.DateTest do
+  use ExShop.ModelCase
+
+  alias ExShop.Product
+  import ExShop.DateTestHelpers
+
+  @tag :validate_gt_ref_date
+  test "Add Error if past date" do
+    changeset = Product.changeset(%Product{}, %{available_on: get_past_date})
+      |> Validations.Date.validate_gt_date(:available_on, get_current_date, message: "should be future date")
+    assert Keyword.get(changeset.errors, :available_on) == "should be future date"
+  end
+
+  @tag :validate_gt_ref_date
+  test "No Error if current date" do
+    changeset = Product.changeset(%Product{}, %{available_on: get_current_date})
+      |> Validations.Date.validate_gt_date(:available_on, get_current_date, message: "should be future date")
+    refute Keyword.get(changeset.errors, :available_on)
+  end
+
+  @tag :validate_gt_ref_date
+  test "No Error if future date" do
+    changeset = Product.changeset(%Product{}, %{available_on: get_future_date})
+      |> Validations.Date.validate_gt_date(:available_on, get_current_date, message: "should be future date")
+    refute Keyword.get(changeset.errors, :available_on)
+  end
+
+  @tag :validate_lt_ref_date
+  test "Add Error if ref_date less than changed value" do
+    changeset = Product.changeset(%Product{}, %{available_on: Ecto.Date.utc})
+      |> Validations.Date.validate_lt_date(:available_on, get_past_date, message: "should be less than REF_DATE")
+    assert Keyword.get(changeset.errors, :available_on) == "should be less than REF_DATE"
+  end
+
+  @tag :validate_lt_ref_date
+  test "No Error if ref_date equal to changed value" do
+    changeset = Product.changeset(%Product{}, %{available_on: Ecto.Date.utc})
+      |> Validations.Date.validate_lt_date(:available_on, Ecto.Date.utc, message: "should be less than REF_DATE")
+    refute Keyword.get(changeset.errors, :available_on)
+  end
+
+  @tag :validate_lt_ref_date
+  test "No Error if ref_date greater than changed date" do
+    changeset = Product.changeset(%Product{}, %{available_on: Ecto.Date.utc})
+      |> Validations.Date.validate_lt_date(:available_on, get_future_date, message: "should be less than REF_DATE")
+    refute Keyword.get(changeset.errors, :available_on)
+  end
+end

--- a/apps/ex_shop/web/models/variant.ex
+++ b/apps/ex_shop/web/models/variant.ex
@@ -43,6 +43,7 @@ defmodule ExShop.Variant do
   def changeset(model, params \\ :empty) do
     model
     |> cast(params, @required_fields, @optional_fields)
+    |> Validations.Date.validate_not_past_date(:discontinue_on)
     |> update_total_quantity
   end
 
@@ -75,6 +76,7 @@ defmodule ExShop.Variant do
 
   def create_variant_changeset(model, params \\ :empty) do
     changeset(model, params)
+    |> validate_discontinue_gt_available_on
     |> put_change(:is_master, false)
     |> cast_attachments(params, ~w(), ~w(image))
     |> cast_assoc(:variant_option_values, required: true, with: &ExShop.VariantOptionValue.from_variant_changeset/2)
@@ -82,6 +84,7 @@ defmodule ExShop.Variant do
 
   def update_variant_changeset(model, params \\ :empty) do
     changeset(model, params)
+    |> validate_discontinue_gt_available_on
     |> validate_not_master
     # Even if changset is invalid, cast_attachments does it work :(
     |> cast_attachments(params, ~w(), ~w(image))

--- a/apps/ex_shop/web/templates/admin/product/form.html.eex
+++ b/apps/ex_shop/web/templates/admin/product/form.html.eex
@@ -60,16 +60,13 @@
         <% end %>
         <%= error_tag m, :image %>
       </div>
-    <% end %>
-  <% end %>
 
-  <%# "If already in DB, that is edit" %>
-  <%= if @changeset.model.id do %>
-    <div class="form-group">
-      <%= label f, :discontinue_on, class: "control-label" %>
-      <%= date_select f, :discontinue_on, class: "form-control" %>
-      <%= error_tag f, :discontinue_on %>
-    </div>
+      <div class="form-group">
+        <%= label m, :discontinue_on, class: "control-label" %>
+        <%= date_select m, :discontinue_on, class: "form-control" %>
+        <%= error_tag m, :discontinue_on %>
+      </div>
+    <% end %>
   <% end %>
 
   <%= inputs_for f, :product_option_types, fn po -> %>

--- a/apps/ex_shop/web/templates/admin/variant/form.html.eex
+++ b/apps/ex_shop/web/templates/admin/variant/form.html.eex
@@ -49,9 +49,9 @@
   </div>
 
   <div class="form-group">
-    <%= label f, :height, class: "control-label" %>
-    <%= number_input f, :height, step: "any", class: "form-control" %>
-    <%= error_tag f, :height %>
+    <%= label f, :depth, class: "control-label" %>
+    <%= number_input f, :depth, step: "any", class: "form-control" %>
+    <%= error_tag f, :depth %>
   </div>
 
   <div class="form-group">

--- a/apps/ex_shop/web/validations/date.ex
+++ b/apps/ex_shop/web/validations/date.ex
@@ -11,7 +11,7 @@ defmodule Validations.Date do
     # ref_date = ref_date || Ecto.Date.utc
     validate_change(changeset, field, fn _,value ->
       case Ecto.Date.compare(value, ref_date) do
-        :lt -> [{field, options[:message] || "should be greater than #{Ecto.Date.to_string(ref_date)}"}]
+        :lt -> [{field, options[:message] || "should be greater or same as #{Ecto.Date.to_string(ref_date)}"}]
         _  -> []
       end
     end)
@@ -23,7 +23,7 @@ defmodule Validations.Date do
     validate_change(changeset, field, fn _,value ->
       # Note the changed references
       case Ecto.Date.compare(ref_date, value) do
-        :lt -> [{field, options[:message] || "should be less than #{Ecto.Date.to_string(ref_date)}"}]
+        :lt -> [{field, options[:message] || "should be less or same as #{Ecto.Date.to_string(ref_date)}"}]
         _  -> []
       end
     end)

--- a/apps/ex_shop/web/validations/date.ex
+++ b/apps/ex_shop/web/validations/date.ex
@@ -1,0 +1,31 @@
+defmodule Validations.Date do
+  import Ecto.Changeset, only: [validate_change: 3]
+
+  def validate_not_past_date(changeset, field, options \\ []) do
+    validate_gt_date(changeset, field, Ecto.Date.utc, [message: options[:message] || "can not be past date"])
+  end
+
+  # Better to add proper validation for Ecto.Date ref_date
+  def validate_gt_date(changeset, field, ref_date, options \\ []) do
+    # Handling ref_date nil cases
+    # ref_date = ref_date || Ecto.Date.utc
+    validate_change(changeset, field, fn _,value ->
+      case Ecto.Date.compare(value, ref_date) do
+        :lt -> [{field, options[:message] || "should be greater than #{Ecto.Date.to_string(ref_date)}"}]
+        _  -> []
+      end
+    end)
+  end
+
+  def validate_lt_date(changeset, field, ref_date, options \\ []) do
+    # Handling ref_date nil cases
+    # ref_date = ref_date || Ecto.Date.load {9999,12,31}
+    validate_change(changeset, field, fn _,value ->
+      # Note the changed references
+      case Ecto.Date.compare(ref_date, value) do
+        :lt -> [{field, options[:message] || "should be less than #{Ecto.Date.to_string(ref_date)}"}]
+        _  -> []
+      end
+    end)
+  end
+end

--- a/docs/ex-shop/style_guides/elixir.md
+++ b/docs/ex-shop/style_guides/elixir.md
@@ -1,0 +1,2 @@
+- https://github.com/niftyn8/elixir_style_guide
+- http://stackoverflow.com/questions/34066395/how-to-import-a-function-with-different-number-of-params

--- a/docs/ex-shop/validations/date.md
+++ b/docs/ex-shop/validations/date.md
@@ -1,0 +1,2 @@
+- http://blog.danielberkompas.com/elixir/2015/05/20/useful-ecto-validators.html
+- https://github.com/elixir-lang/ecto/issues/390#issuecomment-71269649

--- a/docs/ex-shop/validations/general.md
+++ b/docs/ex-shop/validations/general.md
@@ -1,0 +1,3 @@
+- Avoid adding validations in Default changeset which is referring any associated record as might not be available
+  - Moving validate_discontinue_gt_available_on in changeset which is used in VariantController#new
+    - gives error as not able to preload product and throws error on nil.available_on :()


### PR DESCRIPTION
Added DateValidation Helpers
Added Validation for Product available_on and Master Variant discontinue_on to not be past dates
Added Validation to ensure available_on less than Master Variant discontinue_on
Added Validation to ensure Master Variant discontinue_on greater than Product available_on DB value,
Changed Value might have case to enter discontinue_on less than available_on
