### PR TITLE
Add configurable calculators

### DIFF
--- a/apps/nectar/config/dev.exs
+++ b/apps/nectar/config/dev.exs
@@ -41,6 +41,6 @@ config :arc,
 
 import_config "dev.secret.exs"
 
-config :shipping_calculators,
+config :nectar, :shipping_calculators,
   regular: Nectar.ShippingCalculator.Flat,
   express: Nectar.ShippingCalculator.Fast

--- a/apps/nectar/config/dev.exs
+++ b/apps/nectar/config/dev.exs
@@ -40,3 +40,7 @@ config :arc,
   #secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role]
 
 import_config "dev.secret.exs"
+
+config :shipping_calculators,
+  regular: Nectar.ShippingCalculator.Flat,
+  express: Nectar.ShippingCalculator.Fast

--- a/apps/nectar/config/test.exs
+++ b/apps/nectar/config/test.exs
@@ -18,6 +18,12 @@ config :nectar, Nectar.Repo,
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
 
-config :shipping_calculators,
+config :nectar, :shipping_calculators,
   regular: Nectar.ShippingCalculator.Flat,
-  express: Nectar.ShippingCalculator.Random
+  express: Nectar.ShippingCalculator.Random,
+  simple: Nectar.ShippingCalculatorTest.Simple,
+  provided: Nectar.ShippingCalculatorTest.ProvidedShippingRate,
+  overriden_shipping_rate: Nectar.ShippingCalculatorTest.OverridenShippingRate,
+  throws_exception: Nectar.ShippingCalculatorTest.ThrowsException,
+  times_out: Nectar.ShippingCalculatorTest.TimesOut,
+  not_applicable: Nectar.ShippingCalculatorTest.NotApplicable

--- a/apps/nectar/config/test.exs
+++ b/apps/nectar/config/test.exs
@@ -10,10 +10,14 @@ config :nectar, Nectar.Endpoint,
 config :logger, level: :warn
 
 # Configure your database
- config :nectar, Nectar.Repo,
-   adapter: Ecto.Adapters.Postgres,
-   username: "postgres",
-   password: "",
-   database: "nectar_test",
-   hostname: "localhost",
-   pool: Ecto.Adapters.SQL.Sandbox
+config :nectar, Nectar.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  username: "postgres",
+  password: "",
+  database: "nectar_test",
+  hostname: "localhost",
+  pool: Ecto.Adapters.SQL.Sandbox
+
+config :shipping_calculators,
+  regular: Nectar.ShippingCalculator.Flat,
+  express: Nectar.ShippingCalculator.Random

--- a/apps/nectar/test/calculators/shipping_calculator_test.exs
+++ b/apps/nectar/test/calculators/shipping_calculator_test.exs
@@ -1,0 +1,128 @@
+defmodule Nectar.ShippingCalculatorTest do
+  use Nectar.ModelCase
+
+  alias Nectar.Order
+  alias Nectar.ShippingCalculator
+  alias Nectar.ShippingCalculator.Base
+  alias Nectar.ShippingMethod
+
+  defmodule Simple do
+    use Base
+  end
+
+  defmodule ProvidedShippingRate do
+    use Base, shipping_rate: 12
+  end
+
+  defmodule OveriddenShippingRate do
+    use Base
+
+    def shipping_rate(order) do
+      Decimal.new(100)
+    end
+  end
+
+  defmodule ThrowsException do
+    use Base
+
+    def shipping_rate(order) do
+      1/0
+    end
+  end
+
+  defmodule TimesOut do
+    use Base
+
+    def shipping_rate(order) do
+      :timer.sleep(6000)
+      Decimal.new("0")
+    end
+  end
+
+  defmodule NotApplicable do
+    use Base
+
+    def applicable?(order) do
+      false
+    end
+  end
+
+  test "default calculator implementation" do
+    order = create_order
+    assert Simple.applicable?(order) == true
+    assert Simple.shipping_rate(order) == Decimal.new("0")
+    assert Simple.calculate_shipping(order) == {:ok, Decimal.new("0")}
+  end
+
+  test "calculator implementation with provided shipping rate" do
+    order = create_order
+    assert ProvidedShippingRate.applicable?(order) == true
+    assert ProvidedShippingRate.shipping_rate(order) == Decimal.new("12")
+    assert ProvidedShippingRate.calculate_shipping(order) == {:ok, Decimal.new("12")}
+
+  end
+
+  test "calculator implmentation with overriden shipping_rate method" do
+    order = create_order
+    assert OveriddenShippingRate.applicable?(order) == true
+    assert OveriddenShippingRate.shipping_rate(order) == Decimal.new("100")
+    assert OveriddenShippingRate.calculate_shipping(order) == {:ok, Decimal.new("100")}
+  end
+
+  test "calculator implementation with overriden applicable? method" do
+    order = create_order
+    assert NotApplicable.applicable?(order) == false
+    assert NotApplicable.calculate_shipping(order) == {:not_applicable, Decimal.new("0")}
+  end
+
+  @using_calculator ["simple", "provided"]
+  test "shipping calculator run with all applicable calculators returns all" do
+    setup_enabled_calculators(@using_calculator)
+    calculated_shippings = ShippingCalculator.calculate_applicable_shippings(create_order)
+    assert Enum.count(calculated_shippings) == 2
+  end
+
+  @using_calculator ["simple", "throws_exception"]
+  test "shipping calculator run with one exception throwing calculator returns only success" do
+    setup_enabled_calculators(@using_calculator)
+    calculated_shippings = ShippingCalculator.calculate_applicable_shippings(create_order)
+    assert Enum.count(calculated_shippings) == 1
+    shipping = List.first calculated_shippings
+    assert shipping.name == "simple"
+    assert shipping.shipping_cost == Decimal.new("0")
+  end
+
+  @using_calculator ["simple", "not_applicable", "throws_exception"]
+  test "shipping calculator run with one exception throwing and one not applicable calculator returns only success" do
+    setup_enabled_calculators(@using_calculator)
+    calculated_shippings = ShippingCalculator.calculate_applicable_shippings(create_order)
+    assert Enum.count(calculated_shippings) == 1
+    shipping = List.first calculated_shippings
+    assert shipping.name == "simple"
+    assert shipping.shipping_cost == Decimal.new("0")
+  end
+
+  @using_calculator ["simple", "times_out"]
+  test "shipping calculator run with one calculator that times out returns only success" do
+    setup_enabled_calculators(@using_calculator)
+    calculated_shippings = ShippingCalculator.calculate_applicable_shippings(create_order)
+    assert Enum.count(calculated_shippings) == 1
+    shipping = List.first calculated_shippings
+    assert shipping.name == "simple"
+    assert shipping.shipping_cost == Decimal.new("0")
+  end
+
+  defp create_order do
+    Order.cart_changeset(%Order{}, %{})
+    |> Repo.insert!
+  end
+
+  defp setup_enabled_calculators(calculator_names) do
+    Enum.map(calculator_names, fn (name) ->
+      ShippingMethod.changeset(%ShippingMethod{}, %{name: name, enabled: true})
+      |> Nectar.Repo.insert!
+    end)
+  end
+
+
+end

--- a/apps/nectar/test/calculators/shipping_calculator_test.exs
+++ b/apps/nectar/test/calculators/shipping_calculator_test.exs
@@ -35,7 +35,7 @@ defmodule Nectar.ShippingCalculatorTest do
 
     def shipping_rate(order) do
       :timer.sleep(6000)
-      Decimal.new("0")
+      Decimal.new(0)
     end
   end
 
@@ -50,29 +50,29 @@ defmodule Nectar.ShippingCalculatorTest do
   test "default calculator implementation" do
     order = create_order
     assert Simple.applicable?(order) == true
-    assert Simple.shipping_rate(order) == Decimal.new("0")
-    assert Simple.calculate_shipping(order) == {:ok, Decimal.new("0")}
+    assert Simple.shipping_rate(order) == Decimal.new(0)
+    assert Simple.calculate_shipping(order) == {:ok, Decimal.new(0)}
   end
 
   test "calculator implementation with provided shipping rate" do
     order = create_order
     assert ProvidedShippingRate.applicable?(order) == true
-    assert ProvidedShippingRate.shipping_rate(order) == Decimal.new("12")
-    assert ProvidedShippingRate.calculate_shipping(order) == {:ok, Decimal.new("12")}
+    assert ProvidedShippingRate.shipping_rate(order) == Decimal.new(12)
+    assert ProvidedShippingRate.calculate_shipping(order) == {:ok, Decimal.new(12)}
 
   end
 
   test "calculator implmentation with overriden shipping_rate method" do
     order = create_order
     assert OveriddenShippingRate.applicable?(order) == true
-    assert OveriddenShippingRate.shipping_rate(order) == Decimal.new("100")
-    assert OveriddenShippingRate.calculate_shipping(order) == {:ok, Decimal.new("100")}
+    assert OveriddenShippingRate.shipping_rate(order) == Decimal.new(100)
+    assert OveriddenShippingRate.calculate_shipping(order) == {:ok, Decimal.new(100)}
   end
 
   test "calculator implementation with overriden applicable? method" do
     order = create_order
     assert NotApplicable.applicable?(order) == false
-    assert NotApplicable.calculate_shipping(order) == {:not_applicable, Decimal.new("0")}
+    assert NotApplicable.calculate_shipping(order) == {:not_applicable, Decimal.new(0)}
   end
 
   @using_calculator ["simple", "provided"]
@@ -89,7 +89,7 @@ defmodule Nectar.ShippingCalculatorTest do
     assert Enum.count(calculated_shippings) == 1
     shipping = List.first calculated_shippings
     assert shipping.name == "simple"
-    assert shipping.shipping_cost == Decimal.new("0")
+    assert shipping.shipping_cost == Decimal.new(0)
   end
 
   @using_calculator ["simple", "not_applicable", "throws_exception"]
@@ -99,7 +99,7 @@ defmodule Nectar.ShippingCalculatorTest do
     assert Enum.count(calculated_shippings) == 1
     shipping = List.first calculated_shippings
     assert shipping.name == "simple"
-    assert shipping.shipping_cost == Decimal.new("0")
+    assert shipping.shipping_cost == Decimal.new(0)
   end
 
   @using_calculator ["simple", "times_out"]
@@ -109,7 +109,7 @@ defmodule Nectar.ShippingCalculatorTest do
     assert Enum.count(calculated_shippings) == 1
     shipping = List.first calculated_shippings
     assert shipping.name == "simple"
-    assert shipping.shipping_cost == Decimal.new("0")
+    assert shipping.shipping_cost == Decimal.new(0)
   end
 
   defp create_order do

--- a/apps/nectar/web/calculators/shipping_calculator.ex
+++ b/apps/nectar/web/calculators/shipping_calculator.ex
@@ -2,20 +2,14 @@ defmodule Nectar.ShippingCalculator do
   use GenServer
 
   alias __MODULE__
-  alias Nectar.Repo
-  alias Nectar.ShippingMethod
   alias Nectar.Order
   alias Nectar.Repo
-
-  # hold the state in this struct
-  defstruct order: nil, result: [], timer: nil, caller: nil, pending: [], shipping_methods: []
-
-  @shipping_calculation_timeout 5000 # ms
+  alias Nectar.ShippingMethod
 
   # generate all possible shippings
   def calculate_applicable_shippings(%Order{} = order) do
     available_shipping_methods = Repo.all ShippingMethod.enabled_shipping_methods
-    {:ok, server} = ShippingCalculator.start(self(), available_shipping_methods, order)
+    {:ok, server} = ShippingCalculator.Runner.start(self(), available_shipping_methods, order)
     GenServer.cast(server, {:calculate})
     applicable_shippings = receive do
       {:ok, results} -> results
@@ -32,85 +26,11 @@ defmodule Nectar.ShippingCalculator do
   end
 
   defp shipping_calculator_module(method_name) do
-    Application.get_env(:shipping_calculators, String.to_atom(method_name))
+    Application.get_env(:nectar, :shipping_calculators)[String.to_atom(method_name)]
   end
 
   def shipping_cost(%ShippingMethod{name: name}, order) do
     shipping_calculator_module(name).calculate_shipping(order)
   end
-
-  #### Genserver Methods Start Here ####
-
-  def start(caller, shipping_methods, order) do
-    state = %ShippingCalculator{caller: caller, shipping_methods: shipping_methods, order: order}
-    GenServer.start(__MODULE__, state, [])
-  end
-
-  def handle_cast({:calculate}, state) do
-    current = self()
-    proc_list = Enum.map(state.shipping_methods, fn(method) ->
-      spawn_monitor(fn ->
-        send(current, Tuple.append(ShippingCalculator.calculate_shipping_cost(method, state.order), self()))
-      end)
-    end)
-    timer = Process.send_after(current, {:timeout}, @shipping_calculation_timeout)
-    {:noreply, %ShippingCalculator{state|timer: timer, pending: proc_list}}
-  end
-
-  def handle_info({:ok, results, pid}, state) do
-    update_state(state, pid, results)
-    |> send_results_if_completed()
-  end
-
-  # Failure conditions
-  # Process Timedout
-  def handle_info({:timeout}, state) do
-    send state.caller, {:ok, state.result}
-    {:stop, :normal, state}
-  end
-
-  # The process crashed
-  # Note: we deregister the monitor on success to avoid multiple calls per process
-  def handle_info({:DOWN, _, _, pid, _}, state) do #
-    update_state(state, pid)
-    |> send_results_if_completed()
-  end
-
-  # The shipping method is not applicable
-  def handle_info({:not_applicable, _, pid}, state) do
-    update_state(state, pid)
-    |> send_results_if_completed()
-  end
-
-  # Calculator returned an error
-  def handle_info({:error, _reason, pid}, state) do
-    update_state(state, pid)
-    |> send_results_if_completed()
-  end
-
-  # call on failure
-  defp update_state(state, pid) do
-    proc_tuple = List.keyfind(state.pending, pid, 0)
-    updated_pending = List.delete state.pending, proc_tuple
-    %ShippingCalculator{state|pending: updated_pending}
-  end
-
-  # call on success with results
-  defp update_state(state, pid, result) do
-    {pid, monitor} = List.keyfind(state.pending, pid, 0)
-    updated_pending = List.delete state.pending, {pid, monitor}
-    updated_results = [result|state.result]
-    # demonitor to avoid down.
-    Process.demonitor(monitor)
-    %ShippingCalculator{state|pending: updated_pending, result: updated_results}
-  end
-
-  defp send_results_if_completed(%ShippingCalculator{result: result, timer: timer, caller: caller, pending: []} = updated_state) do
-    Process.cancel_timer(timer)
-    send caller, {:ok, result}
-    # stop the server since all processes have returned
-    {:stop, :normal, updated_state}
-  end
-  defp send_results_if_completed(%ShippingCalculator{} = updated_state), do: {:noreply, updated_state}
 
 end

--- a/apps/nectar/web/calculators/shipping_calculator.ex
+++ b/apps/nectar/web/calculators/shipping_calculator.ex
@@ -1,25 +1,116 @@
 defmodule Nectar.ShippingCalculator do
+  use GenServer
+
+  alias __MODULE__
+  alias Nectar.Repo
+  alias Nectar.ShippingMethod
   alias Nectar.Order
   alias Nectar.Repo
 
+  # hold the state in this struct
+  defstruct order: nil, result: [], timer: nil, caller: nil, pending: [], shipping_methods: []
+
+  @shipping_calculation_timeout 5000 # ms
+
   # generate all possible shippings
   def calculate_applicable_shippings(%Order{} = order) do
-    # replace with a distributed worker/async approach
-    # collect all available results avoid awaiting for all
-    # see: http://theerlangelist.com/article/beyond_taskasync for reference
-    Enum.map(Repo.all(Nectar.ShippingMethod.enabled_shipping_methods), fn (shipping_method) -> calculate_shipping_cost(shipping_method, order) end)
+    available_shipping_methods = Repo.all ShippingMethod.enabled_shipping_methods
+    {:ok, server} = ShippingCalculator.start(self(), available_shipping_methods, order)
+    GenServer.cast(server, {:calculate})
+    applicable_shippings = receive do
+      {:ok, results} -> results
+    end
+    applicable_shippings
   end
 
-  def calculate_shipping_cost(shipping_method, order) do
+  def calculate_shipping_cost(%ShippingMethod{} = shipping_method, order) do
     # launch the shipping calculator here.
-    Map.from_struct(%Nectar.ShippingMethod{shipping_method|shipping_cost: shipping_cost(shipping_method, order)})
-    |> Map.drop([:__meta__, :shippings])
+    {status, calculated_shipping_cost} = shipping_cost(shipping_method, order)
+    cost = Map.from_struct(%ShippingMethod{shipping_method|shipping_cost: calculated_shipping_cost})
+    |> Map.drop([:__meta__, :shippings, :inserted_at, :updated_at])
+    {status, cost}
   end
 
-  def shipping_cost(_method, _order) do
-    # link this with ETS to allow quick look up once done.
-    # will be dispatched to the corresponding worker which either calculates it
-    # or returns with a quick lookup
-    Decimal.new(10)
+  defp shipping_calculator_module(method_name) do
+    Application.get_env(:shipping_calculators, String.to_atom(method_name))
   end
+
+  def shipping_cost(%ShippingMethod{name: name}, order) do
+    shipping_calculator_module(name).calculate_shipping(order)
+  end
+
+  #### Genserver Methods Start Here ####
+
+  def start(caller, shipping_methods, order) do
+    state = %ShippingCalculator{caller: caller, shipping_methods: shipping_methods, order: order}
+    GenServer.start(__MODULE__, state, [])
+  end
+
+  def handle_cast({:calculate}, state) do
+    current = self()
+    proc_list = Enum.map(state.shipping_methods, fn(method) ->
+      spawn_monitor(fn ->
+        send(current, Tuple.append(ShippingCalculator.calculate_shipping_cost(method, state.order), self()))
+      end)
+    end)
+    timer = Process.send_after(current, {:timeout}, @shipping_calculation_timeout)
+    {:noreply, %ShippingCalculator{state|timer: timer, pending: proc_list}}
+  end
+
+  def handle_info({:ok, results, pid}, state) do
+    update_state(state, pid, results)
+    |> send_results_if_completed()
+  end
+
+  # Failure conditions
+  # Process Timedout
+  def handle_info({:timeout}, state) do
+    send state.caller, {:ok, state.result}
+    {:stop, :normal, state}
+  end
+
+  # The process crashed
+  # Note: we deregister the monitor on success to avoid multiple calls per process
+  def handle_info({:DOWN, _, _, pid, _}, state) do #
+    update_state(state, pid)
+    |> send_results_if_completed()
+  end
+
+  # The shipping method is not applicable
+  def handle_info({:not_applicable, _, pid}, state) do
+    update_state(state, pid)
+    |> send_results_if_completed()
+  end
+
+  # Calculator returned an error
+  def handle_info({:error, _reason, pid}, state) do
+    update_state(state, pid)
+    |> send_results_if_completed()
+  end
+
+  # call on failure
+  defp update_state(state, pid) do
+    proc_tuple = List.keyfind(state.pending, pid, 0)
+    updated_pending = List.delete state.pending, proc_tuple
+    %ShippingCalculator{state|pending: updated_pending}
+  end
+
+  # call on success with results
+  defp update_state(state, pid, result) do
+    {pid, monitor} = List.keyfind(state.pending, pid, 0)
+    updated_pending = List.delete state.pending, {pid, monitor}
+    updated_results = [result|state.result]
+    # demonitor to avoid down.
+    Process.demonitor(monitor)
+    %ShippingCalculator{state|pending: updated_pending, result: updated_results}
+  end
+
+  defp send_results_if_completed(%ShippingCalculator{result: result, timer: timer, caller: caller, pending: []} = updated_state) do
+    Process.cancel_timer(timer)
+    send caller, {:ok, result}
+    # stop the server since all processes have returned
+    {:stop, :normal, updated_state}
+  end
+  defp send_results_if_completed(%ShippingCalculator{} = updated_state), do: {:noreply, updated_state}
+
 end

--- a/apps/nectar/web/calculators/shipping_calculator/base.ex
+++ b/apps/nectar/web/calculators/shipping_calculator/base.ex
@@ -8,7 +8,7 @@ defmodule Nectar.ShippingCalculator.Base do
   end
 
   defmacro __using__(_) do
-    add_shipping_methods("0")
+    add_shipping_methods(0)
   end
 
   def add_shipping_methods(shipping) do
@@ -19,7 +19,7 @@ defmodule Nectar.ShippingCalculator.Base do
         if applicable? order do
           {:ok, shipping_rate(order)}
         else
-          {:not_applicable, Decimal.new("0")}
+          {:not_applicable, Decimal.new(0)}
         end
       end
 

--- a/apps/nectar/web/calculators/shipping_calculator/base.ex
+++ b/apps/nectar/web/calculators/shipping_calculator/base.ex
@@ -1,0 +1,38 @@
+defmodule Nectar.ShippingCalculator.Base do
+  @callback calculate_shipping(Nectar.Order.t) :: any
+  @callback applicable?(Nectar.Order.t) :: any
+  @callback shipping_rate(Nectar.Order.t) :: any
+
+  defmacro __using__([shipping_rate: provided_shipping_rate]) do
+    add_shipping_methods(provided_shipping_rate)
+  end
+
+  defmacro __using__(_) do
+    add_shipping_methods("0")
+  end
+
+  def add_shipping_methods(shipping) do
+    quote location: :keep do
+
+      @behaviour Nectar.ShippingCalculator.Base
+      def calculate_shipping(order) do
+        if applicable? order do
+          {:ok, shipping_rate(order)}
+        else
+          {:not_applicable, Decimal.new("0")}
+        end
+      end
+
+      def applicable?(order) do
+        true
+      end
+
+      def shipping_rate(order) do
+        Decimal.new(unquote(shipping))
+      end
+
+      defoverridable [calculate_shipping: 1, applicable?: 1, shipping_rate: 1]
+    end
+  end
+
+end

--- a/apps/nectar/web/calculators/shipping_calculator/fast.ex
+++ b/apps/nectar/web/calculators/shipping_calculator/fast.ex
@@ -1,0 +1,3 @@
+defmodule Nectar.ShippingCalculator.Fast do
+  use Nectar.ShippingCalculator.Base, shipping_rate: "10"
+end

--- a/apps/nectar/web/calculators/shipping_calculator/fast.ex
+++ b/apps/nectar/web/calculators/shipping_calculator/fast.ex
@@ -1,3 +1,3 @@
 defmodule Nectar.ShippingCalculator.Fast do
-  use Nectar.ShippingCalculator.Base, shipping_rate: "10"
+  use Nectar.ShippingCalculator.Base, shipping_rate: 10
 end

--- a/apps/nectar/web/calculators/shipping_calculator/flat.ex
+++ b/apps/nectar/web/calculators/shipping_calculator/flat.ex
@@ -1,0 +1,3 @@
+defmodule Nectar.ShippingCalculator.Flat do
+  use Nectar.ShippingCalculator.Base, shipping_rate: "12"
+end

--- a/apps/nectar/web/calculators/shipping_calculator/flat.ex
+++ b/apps/nectar/web/calculators/shipping_calculator/flat.ex
@@ -1,3 +1,3 @@
 defmodule Nectar.ShippingCalculator.Flat do
-  use Nectar.ShippingCalculator.Base, shipping_rate: "12"
+  use Nectar.ShippingCalculator.Base, shipping_rate: 12
 end

--- a/apps/nectar/web/calculators/shipping_calculator/random.ex
+++ b/apps/nectar/web/calculators/shipping_calculator/random.ex
@@ -1,0 +1,8 @@
+defmodule Nectar.ShippingCalculator.Random do
+  use Nectar.ShippingCalculator.Base
+
+  def shipping_rate(_order) do
+    :random.seed(:os.timestamp)
+    Decimal.new(:random.uniform(200))
+  end
+end

--- a/apps/nectar/web/calculators/shipping_calculator/runner.ex
+++ b/apps/nectar/web/calculators/shipping_calculator/runner.ex
@@ -27,29 +27,26 @@ defmodule Nectar.ShippingCalculator.Runner do
     update_state(state, pid, results)
     |> send_results_if_completed()
   end
-
-  # Failure conditions
-  # Process Timedout
   def handle_info({:timeout}, state) do
+    # Failure conditions
+    # Process Timedout
     send state.caller, {:ok, state.result}
     {:stop, :normal, state}
   end
-
-  # The process crashed
-  # Note: we deregister the monitor on success to avoid multiple calls per process
   def handle_info({:DOWN, _, _, pid, _}, state) do #
+    # The process crashed
+    # Note: we deregister the monitor on success to avoid multiple calls per process
     update_state(state, pid)
     |> send_results_if_completed()
   end
 
-  # The shipping method is not applicable
   def handle_info({:not_applicable, _, pid}, state) do
+    # The shipping method is not applicable
     update_state(state, pid)
     |> send_results_if_completed()
   end
-
-  # Calculator returned an error
   def handle_info({:error, _reason, pid}, state) do
+    # Calculator returned an error
     update_state(state, pid)
     |> send_results_if_completed()
   end
@@ -60,8 +57,6 @@ defmodule Nectar.ShippingCalculator.Runner do
     updated_pending = List.delete state.pending, proc_tuple
     %State{state|pending: updated_pending}
   end
-
-  # call on success with results
   defp update_state(state, pid, result) do
     {pid, monitor} = List.keyfind(state.pending, pid, 0)
     updated_pending = List.delete state.pending, {pid, monitor}

--- a/apps/nectar/web/calculators/shipping_calculator/runner.ex
+++ b/apps/nectar/web/calculators/shipping_calculator/runner.ex
@@ -1,0 +1,82 @@
+defmodule Nectar.ShippingCalculator.Runner do
+  use GenServer
+
+  alias Nectar.ShippingCalculator
+
+  @shipping_calculation_timeout 5000 # ms
+
+  defmodule State, do: defstruct order: nil, result: [], timer: nil, caller: nil, pending: [], shipping_methods: []
+
+  def start(caller, shipping_methods, order) do
+    state = %State{caller: caller, shipping_methods: shipping_methods, order: order}
+    GenServer.start(__MODULE__, state, [])
+  end
+
+  def handle_cast({:calculate}, state) do
+    current = self()
+    proc_list = Enum.map(state.shipping_methods, fn(method) ->
+      spawn_monitor(fn ->
+        send(current, Tuple.append(ShippingCalculator.calculate_shipping_cost(method, state.order), self()))
+      end)
+    end)
+    timer = Process.send_after(current, {:timeout}, @shipping_calculation_timeout)
+    {:noreply, %State{state|timer: timer, pending: proc_list}}
+  end
+
+  def handle_info({:ok, results, pid}, state) do
+    update_state(state, pid, results)
+    |> send_results_if_completed()
+  end
+
+  # Failure conditions
+  # Process Timedout
+  def handle_info({:timeout}, state) do
+    send state.caller, {:ok, state.result}
+    {:stop, :normal, state}
+  end
+
+  # The process crashed
+  # Note: we deregister the monitor on success to avoid multiple calls per process
+  def handle_info({:DOWN, _, _, pid, _}, state) do #
+    update_state(state, pid)
+    |> send_results_if_completed()
+  end
+
+  # The shipping method is not applicable
+  def handle_info({:not_applicable, _, pid}, state) do
+    update_state(state, pid)
+    |> send_results_if_completed()
+  end
+
+  # Calculator returned an error
+  def handle_info({:error, _reason, pid}, state) do
+    update_state(state, pid)
+    |> send_results_if_completed()
+  end
+
+  # call on failure
+  defp update_state(state, pid) do
+    proc_tuple = List.keyfind(state.pending, pid, 0)
+    updated_pending = List.delete state.pending, proc_tuple
+    %State{state|pending: updated_pending}
+  end
+
+  # call on success with results
+  defp update_state(state, pid, result) do
+    {pid, monitor} = List.keyfind(state.pending, pid, 0)
+    updated_pending = List.delete state.pending, {pid, monitor}
+    updated_results = [result|state.result]
+    # demonitor to avoid down.
+    Process.demonitor(monitor)
+    %State{state|pending: updated_pending, result: updated_results}
+  end
+
+  defp send_results_if_completed(%State{result: result, timer: timer, caller: caller, pending: []} = updated_state) do
+    Process.cancel_timer(timer)
+    send caller, {:ok, result}
+    # stop the server since all processes have returned
+    {:stop, :normal, updated_state}
+  end
+  defp send_results_if_completed(%State{} = updated_state), do: {:noreply, updated_state}
+
+end

--- a/apps/nectar/web/calculators/shipping_calculator/slow.ex
+++ b/apps/nectar/web/calculators/shipping_calculator/slow.ex
@@ -1,0 +1,7 @@
+defmodule Nectar.ShippingCalculator.Slow do
+  use Nectar.ShippingCalculator.Base, shipping_rate: "2"
+
+  def applicable?(_order) do
+    false
+  end
+end

--- a/apps/nectar/web/calculators/shipping_calculator/slow.ex
+++ b/apps/nectar/web/calculators/shipping_calculator/slow.ex
@@ -1,5 +1,5 @@
 defmodule Nectar.ShippingCalculator.Slow do
-  use Nectar.ShippingCalculator.Base, shipping_rate: "2"
+  use Nectar.ShippingCalculator.Base, shipping_rate: 2
 
   def applicable?(_order) do
     false

--- a/apps/nectar/web/models/order.ex
+++ b/apps/nectar/web/models/order.ex
@@ -320,8 +320,9 @@ defmodule Nectar.Order do
   defp shipping_params(_order, %{"shipping" => %{"shipping_method_id" => ""}} = params), do: params
   defp shipping_params(order, %{"shipping" => shipping_params} = params) do
     shipping_method = Nectar.Repo.get(Nectar.ShippingMethod, shipping_params["shipping_method_id"])
+    {:ok, shipping_cost} = Nectar.ShippingCalculator.shipping_cost(shipping_method, order)
     %{params | "shipping" => %{shipping_method_id: shipping_method.id,
-                              adjustment: %{amount: Nectar.ShippingCalculator.shipping_cost(shipping_method, order), order_id: order.id}}}
+                              adjustment: %{amount: shipping_cost, order_id: order.id}}}
   end
   defp shipping_params(_order, params), do: params
 


### PR DESCRIPTION
1. Adds a new behaviour for Shipping Calculator.
2. Few Sample Calculators are implemented for reference.
3. Update the ShippingCalculator module to run all calculators in parallel. In case any of them fails i.e. throws an exception, is not applicable or errors out, it will ignore that result and only return the ones that were successful.
4. To link a shipping method to a calculator, have a look at dev.exs config
