### PR TITLE
generalize the payment authorization method dispatch

### DIFF
--- a/apps/nectar/web/gateways/braintree.ex
+++ b/apps/nectar/web/gateways/braintree.ex
@@ -1,4 +1,4 @@
-defmodule Nectar.Gateway.BrainTree do
+defmodule Nectar.Gateway.Braintree do
   alias Nectar.Repo
   alias Commerce.Billing.Address
   alias Commerce.Billing.CreditCard

--- a/apps/nectar/web/gateways/cheque.ex
+++ b/apps/nectar/web/gateways/cheque.ex
@@ -1,0 +1,6 @@
+defmodule Nectar.Gateway.Cheque do
+  # no processing to be done, acts as a dummy gateway for now.
+  def authorize(_, _) do
+    {:ok}
+  end
+end

--- a/apps/nectar/web/gateways/gateway.ex
+++ b/apps/nectar/web/gateways/gateway.ex
@@ -7,15 +7,8 @@ defmodule Nectar.Gateway do
     Nectar.Repo.get!(Nectar.PaymentMethod, selected_payment_id) |> Map.get(:name)
   end
 
-  defp do_authorize_payment(order, "stripe", payment_method_params) do
-    Nectar.Gateway.Stripe.authorize(order, payment_method_params["stripe"])
-  end
-
-  defp do_authorize_payment(order, "braintree", payment_method_params) do
-    Nectar.Gateway.BrainTree.authorize(order, payment_method_params["braintree"])
-  end
-
-  defp do_authorize_payment(_order, "cheque", _params) do
-    {:ok}
+  defp do_authorize_payment(order, method_name, params) do
+    payment_module = Module.concat(Nectar.Gateway, (Macro.camelize method_name))
+    apply(payment_module, :authorize, [order, params[method_name]])
   end
 end

--- a/apps/nectar/web/views/admin/checkout_view.ex
+++ b/apps/nectar/web/views/admin/checkout_view.ex
@@ -37,7 +37,7 @@ defmodule Nectar.Admin.CheckoutView do
   end
 
   def braintree_client_token do
-    Nectar.Gateway.BrainTree.client_token
+    Nectar.Gateway.Braintree.client_token
   end
 
   def next_step(%Nectar.Order{state: state, confirmation_status: true} = order) do

--- a/apps/nectar/web/views/checkout_view.ex
+++ b/apps/nectar/web/views/checkout_view.ex
@@ -37,7 +37,7 @@ defmodule Nectar.CheckoutView do
   end
 
   def braintree_client_token do
-    Nectar.Gateway.BrainTree.client_token
+    Nectar.Gateway.Braintree.client_token
   end
 
   def next_step(%Nectar.Order{state: state, confirmation_status: true} = order) do


### PR DESCRIPTION
Instead of using hardcoded one pattern per payment method, use a convention based method dispatch bridging the calls between nectar and payment provider. This allows adding new methods for payment without modifying the gateways.ex file and adding more matches.
