### PR TITLE
be more explicit if there are no enabled shipping methods

### DIFF
--- a/apps/nectar/test/calculators/shipping_calculator_test.exs
+++ b/apps/nectar/test/calculators/shipping_calculator_test.exs
@@ -112,6 +112,12 @@ defmodule Nectar.ShippingCalculatorTest do
     assert shipping.shipping_cost == Decimal.new(0)
   end
 
+  test "if no calculators are enabled it returns an empty list" do
+    calculated_shippings = ShippingCalculator.calculate_applicable_shippings(create_order)
+    assert Enum.count(calculated_shippings) == 0
+    assert calculated_shippings == []
+  end
+
   defp create_order do
     Order.cart_changeset(%Order{}, %{})
     |> Repo.insert!

--- a/apps/nectar/web/calculators/shipping_calculator.ex
+++ b/apps/nectar/web/calculators/shipping_calculator.ex
@@ -8,15 +8,15 @@ defmodule Nectar.ShippingCalculator do
 
   # generate all possible shippings
   def calculate_applicable_shippings(%Order{} = order) do
-    case Repo.all ShippingMethod.enabled_shipping_methods do
-      [] -> []
-      available_shipping_methods ->
-        {:ok, server} = ShippingCalculator.Runner.start(self(), available_shipping_methods, order)
+    available_shipping_methods = Repo.all ShippingMethod.enabled_shipping_methods
+    # let it crash in any other situation
+    case ShippingCalculator.Runner.start(self(), available_shipping_methods, order) do
+      {:ok, server} ->
         GenServer.cast(server, {:calculate})
-        applicable_shippings = receive do
+        receive do
           {:ok, results} -> results
         end
-        applicable_shippings
+      {:no_shipping_methods} -> []
     end
   end
 

--- a/apps/nectar/web/calculators/shipping_calculator/runner.ex
+++ b/apps/nectar/web/calculators/shipping_calculator/runner.ex
@@ -7,6 +7,7 @@ defmodule Nectar.ShippingCalculator.Runner do
 
   defmodule State, do: defstruct order: nil, result: [], timer: nil, caller: nil, pending: [], shipping_methods: []
 
+  def start(caller, [], order), do: {:no_shipping_methods}
   def start(caller, shipping_methods, order) do
     state = %State{caller: caller, shipping_methods: shipping_methods, order: order}
     GenServer.start(__MODULE__, state, [])


### PR DESCRIPTION
It basically shifts all responsibility to runner on how to handle the data instead of keeping it seperated in two parts one in runner and other in calculator. This way calculator only handles the runner's response with the data provided. So, we can add additional logic later around :no_shipping_methods if we do not want the empty list.
